### PR TITLE
Fix-popup-arrow

### DIFF
--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "description": "A forward-thinking library of web components.",
-  "version": "3.0.0-beta.4.ha.2",
+  "version": "3.0.0-beta.4.ha.3",
   "homepage": "https://webawesome.com/",
   "author": "Web Awesome",
   "license": "MIT",

--- a/packages/webawesome/src/components/popup/popup.css
+++ b/packages/webawesome/src/components/popup/popup.css
@@ -41,7 +41,6 @@
 .popup:not(.popup-active) {
   display: none;
 }
-
 .arrow {
   position: absolute;
   width: calc(var(--arrow-size-diagonal) * 2);
@@ -49,6 +48,7 @@
   rotate: 45deg;
   background: var(--arrow-color);
   z-index: 3;
+  clip-path: polygon(0 100%, 100% 0, 100% 100%);
 }
 
 :host([data-current-placement~='left']) .arrow {


### PR DESCRIPTION
Arrow was not really an arrow but an rect and so it was able to hide content when padding was too small.

This PR cuts the arrow rect in half to be a real arrow.