### PR TITLE
Prevent popover close on click body

### DIFF
--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -128,12 +128,13 @@ export default class WaPopover extends WebAwesomeElement {
   };
 
   private handleBodyClick = (event: PointerEvent) => {
+    // prevent close from document click handler
+    event.stopPropagation();
     const target = event.target as HTMLElement;
     const button = target.closest('[data-popover="close"]');
 
     // Watch for [data-popover="close"] clicks
     if (button) {
-      event.stopPropagation();
       this.open = false;
     }
   };


### PR DESCRIPTION
 When click inside the body the event also handles `handleDocumentClick`, at least in home-assistant frontend.
 
 I think it's related with our web component architecture.