### PR TITLE
Fix update scroll buttons

### DIFF
--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "description": "A forward-thinking library of web components.",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.6.ha.0",
   "homepage": "https://webawesome.com/",
   "author": "Web Awesome",
   "license": "MIT",

--- a/packages/webawesome/src/components/tab-group/tab-group.ts
+++ b/packages/webawesome/src/components/tab-group/tab-group.ts
@@ -461,7 +461,7 @@ export default class WaTabGroup extends WebAwesomeElement {
           <div
             class="nav"
             @focus=${() => this.activeTab?.focus({ preventScroll: true })}
-            @scrollend=${this.updateScrollButtons}
+            @scroll=${this.updateScrollButtons}
           >
             <div part="tabs" class="tabs" role="tablist">
               <slot name="nav" @slotchange=${this.syncTabsAndPanels}></slot>


### PR DESCRIPTION
Use `scroll` instead of `scrollend` to support all browsers and improve update speed.