### PR TITLE
Fix-button-tap-highlight

### DIFF
--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "description": "A forward-thinking library of web components.",
-  "version": "3.0.0-beta.6.ha.0",
+  "version": "3.0.0-beta.6.ha.1",
   "homepage": "https://webawesome.com/",
   "author": "Web Awesome",
   "license": "MIT",

--- a/packages/webawesome/src/components/button/button.css
+++ b/packages/webawesome/src/components/button/button.css
@@ -1,9 +1,11 @@
 @layer wa-component {
   :host {
     display: inline-block;
+    border-radius: var(--wa-form-control-border-radius);
+    overflow: hidden;
 
     /* Workaround because Chrome doesn't like :host(:has()) below
-     * https://issues.chromium.org/issues/40062355 
+     * https://issues.chromium.org/issues/40062355
      * Firefox doesn't like this nested rule, so both are needed */
     &:has(wa-badge) {
       position: relative;

--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -134,13 +134,12 @@ export default class WaPopover extends WebAwesomeElement {
   };
 
   private handleBodyClick = (event: PointerEvent) => {
-    // prevent close from document click handler
-    event.stopPropagation();
     const target = event.target as HTMLElement;
     const button = target.closest('[data-popover="close"]');
 
     // Watch for [data-popover="close"] clicks
     if (button) {
+      event.stopPropagation();
       this.open = false;
     }
   };

--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -134,12 +134,13 @@ export default class WaPopover extends WebAwesomeElement {
   };
 
   private handleBodyClick = (event: PointerEvent) => {
+    // prevent close from document click handler
+    event.stopPropagation();
     const target = event.target as HTMLElement;
     const button = target.closest('[data-popover="close"]');
 
     // Watch for [data-popover="close"] clicks
     if (button) {
-      event.stopPropagation();
       this.open = false;
     }
   };


### PR DESCRIPTION
Android Chrome shows a tap highlight, when you tap a button.

But this doesn't respect the border radius of the button.

before:
![button-before](https://github.com/user-attachments/assets/9143235a-bb84-4df3-b9e5-285b9bb0e423)

after:
![button-after](https://github.com/user-attachments/assets/402d922a-302f-4f50-99b4-d780da03f641)
