### PR TITLE
Fix popover initial open state

### DIFF
--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "description": "A forward-thinking library of web components.",
-  "version": "3.0.0-beta.6.ha.2",
+  "version": "3.0.0-beta.6.ha.3",
   "homepage": "https://webawesome.com/",
   "author": "Web Awesome",
   "license": "MIT",

--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -116,9 +116,7 @@ export default class WaPopover extends WebAwesomeElement {
   firstUpdated() {
     // If the popover is visible on init, update its position
     if (this.open) {
-      this.dialog.show();
-      this.popup.active = true;
-      this.popup.reposition();
+      this.handleOpenChange();
     }
   }
 
@@ -202,6 +200,10 @@ export default class WaPopover extends WebAwesomeElement {
           this.dialog.focus();
         }
       });
+
+      if (!this.popup.popup) {
+        await this.popup.updateComplete;
+      }
 
       await animateWithClass(this.popup.popup, 'show-with-scale');
       this.popup.reposition();


### PR DESCRIPTION
Use `handleOpenChange` to open a popover that was created with `open=true` to have have the same behaviour as when open after initial loading.