### PR TITLE
button: disable tap-highlight

### DIFF
--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "description": "A forward-thinking library of web components.",
-  "version": "3.0.0-beta.6.ha.3",
+  "version": "3.0.0-beta.6.ha.4",
   "homepage": "https://webawesome.com/",
   "author": "Web Awesome",
   "license": "MIT",

--- a/packages/webawesome/src/components/button/button.css
+++ b/packages/webawesome/src/components/button/button.css
@@ -2,7 +2,7 @@
   :host {
     display: inline-block;
     border-radius: var(--wa-form-control-border-radius);
-    overflow: hidden;
+    -webkit-tap-highlight-color: transparent;
 
     /* Workaround because Chrome doesn't like :host(:has()) below
      * https://issues.chromium.org/issues/40062355


### PR DESCRIPTION
- Remove overflow hidden
  - this removed the ability to visually focus the button with the keyboard
- Set tap-highlight-color to transparent