### PR TITLE
Add trap focus to popover

### DIFF
--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "description": "A forward-thinking library of web components.",
-  "version": "3.0.0-beta.6.ha.4",
+  "version": "3.0.0-beta.6.ha.5",
   "homepage": "https://webawesome.com/",
   "author": "Web Awesome",
   "license": "MIT",

--- a/packages/webawesome/src/components/popover/popover.css
+++ b/packages/webawesome/src/components/popover/popover.css
@@ -39,6 +39,10 @@
   }
 }
 
+.dialog::backdrop {
+  background: transparent;
+}
+
 /* The <wa-popup> element */
 .popover {
   --arrow-size: inherit;

--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -95,7 +95,7 @@ export default class WaPopover extends WebAwesomeElement {
   @property({ attribute: 'auto-size-padding', type: Number }) autoSizePadding = 0;
 
   /** Keep keyboard focus within the popover */
-  @property({ attribute: 'focus-trap', type: Boolean }) focusTrap = false;
+  @property({ attribute: 'trap-focus', type: Boolean }) trapFocus = false;
 
   private eventController = new AbortController();
 
@@ -188,7 +188,7 @@ export default class WaPopover extends WebAwesomeElement {
       document.addEventListener('keydown', this.handleDocumentKeyDown, { signal: this.eventController.signal });
       document.addEventListener('click', this.handleDocumentClick, { signal: this.eventController.signal });
 
-      if (this.focusTrap) {
+      if (this.trapFocus) {
         // Show the dialog modally to trap focus
         this.dialog.showModal();
       } else {

--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -94,6 +94,9 @@ export default class WaPopover extends WebAwesomeElement {
   /** The amount of padding, in pixels, to exceed before the auto-size behavior will occur. */
   @property({ attribute: 'auto-size-padding', type: Number }) autoSizePadding = 0;
 
+  /** Keep keyboard focus within the popover */
+  @property({ attribute: 'focus-trap', type: Boolean }) focusTrap = false;
+
   private eventController = new AbortController();
 
   connectedCallback() {
@@ -185,8 +188,13 @@ export default class WaPopover extends WebAwesomeElement {
       document.addEventListener('keydown', this.handleDocumentKeyDown, { signal: this.eventController.signal });
       document.addEventListener('click', this.handleDocumentClick, { signal: this.eventController.signal });
 
-      // Show the dialog non-modally
-      this.dialog.show();
+      if (this.focusTrap) {
+        // Show the dialog modally to trap focus
+        this.dialog.showModal();
+      } else {
+        // Show the dialog non-modally
+        this.dialog.show();
+      }
       this.popup.active = true;
       openPopovers.add(this);
 


### PR DESCRIPTION
Add modal option for the popover to have trap focus. If a popover is interactive it should be trapped. Important for a11y is that the correct aria attributes are set.