### PR TITLE
Fix native dialog cancel on  trap-focus activated popover

### DIFF
--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "description": "A forward-thinking library of web components.",
-  "version": "3.0.0-beta.6.ha.5",
+  "version": "3.0.0-beta.6.ha.6",
   "homepage": "https://webawesome.com/",
   "author": "Web Awesome",
   "license": "MIT",

--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -302,9 +302,17 @@ export default class WaPopover extends WebAwesomeElement {
     return waitForEvent(this, 'wa-after-hide');
   }
 
+  private handleDialogCancel(event: Event) {
+    event.preventDefault();
+
+    if (!this.dialog.classList.contains('hide')) {
+      this.open = false;
+    }
+  }
+
   render() {
     return html`
-      <dialog part="dialog" class="dialog">
+      <dialog part="dialog" class="dialog" @cancel=${this.handleDialogCancel}>
         <wa-popup
           part="popup"
           exportparts="


### PR DESCRIPTION
We need to skip native dialog cancel to be able to show the animation correctly. 
I did it as it's done in wa-drawer