### PR TITLE
Fix import of `wa-popup` for dropdown

### DIFF
--- a/packages/webawesome/src/components/dropdown/dropdown.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.ts
@@ -17,7 +17,8 @@ import { LocalizeController } from '../../utilities/localize.js';
 import type WaButton from '../button/button.js';
 import '../dropdown-item/dropdown-item.js';
 import type WaDropdownItem from '../dropdown-item/dropdown-item.js';
-import WaPopup from '../popup/popup.js'; // Added import for wa-popup
+import '../popup/popup.js';
+import type WaPopup from '../popup/popup.js';
 import styles from './dropdown.styles.js';
 
 const openDropdowns = new Set<WaDropdown>();


### PR DESCRIPTION
Import to properly register custom element `wa-popup`.

In HA this is, as far as I have seen, not a problem since `ha-tooltip`, `ha-label` or some other seems to always be in scope - which already imports `wa-popup`. 
The issue shows when loading a `hass-subpage-data-table` in an iframe. Then the grouping and sorting dropdown buttons don't render properly.

<img width="1467" height="395" alt="Bildschirmfoto 2026-02-07 um 18 07 56" src="https://github.com/user-attachments/assets/96623b2c-8828-4e37-837f-94e48f8cc635" />

Tested with `"@home-assistant/webawesome": "3.0.0-ha.2"`. Current `next` seems to have changed since then though. I still think this will apply as `<wa-popup>` is still used here.

I also opened an upstream PR: https://github.com/shoelace-style/webawesome/pull/2043