### PR TITLE
Fix popup arrow overlapping text

### DIFF
--- a/packages/webawesome/src/components/popover/popover.styles.ts
+++ b/packages/webawesome/src/components/popover/popover.styles.ts
@@ -7,9 +7,6 @@ export default css`
     --show-duration: 100ms;
     --hide-duration: 100ms;
 
-    /* Internal calculated properties */
-    --arrow-diagonal-size: calc((var(--arrow-size) * sin(45deg)));
-
     display: contents;
 
     /** Defaults for inherited CSS properties */
@@ -45,6 +42,7 @@ export default css`
   /* The <wa-popup> element */
   .popover {
     --arrow-size: inherit;
+    --arrow-border-size: var(--wa-panel-border-width);
     --show-duration: inherit;
     --hide-duration: inherit;
 

--- a/packages/webawesome/src/components/popup/popup.styles.ts
+++ b/packages/webawesome/src/components/popup/popup.styles.ts
@@ -62,17 +62,17 @@ export default css`
     translate: 0 calc(var(--arrow-offset) * -1);
   }
 
-  :host([data-current-placement~='left']) .arrow {
+  :host([data-current-placement^='left']) .arrow {
     rotate: -45deg;
     translate: calc(var(--arrow-offset) * -1) 0;
   }
 
-  :host([data-current-placement~='right']) .arrow {
+  :host([data-current-placement^='right']) .arrow {
     rotate: 135deg;
     translate: var(--arrow-offset) 0;
   }
 
-  :host([data-current-placement~='bottom']) .arrow {
+  :host([data-current-placement^='bottom']) .arrow {
     rotate: 225deg;
     translate: 0 var(--arrow-offset);
   }

--- a/packages/webawesome/src/components/popup/popup.styles.ts
+++ b/packages/webawesome/src/components/popup/popup.styles.ts
@@ -4,14 +4,20 @@ export default css`
   :host {
     --arrow-color: black;
     --arrow-size: var(--wa-tooltip-arrow-size);
+    --arrow-border-size: 0;
     --show-duration: 100ms;
     --hide-duration: 100ms;
 
     /*
      * These properties are computed to account for the arrow's dimensions after being rotated 45º. The constant
      * 0.7071 is derived from sin(45), which is the diagonal size of the arrow's container after rotating.
+     *
+     * The diamond will be translated inward by the border thickness to ensure crop point is o the inner edge of
+     * the border. This also means we need to increase the size of the diamond by sqrt(2) time the border width
+     * to keep it central (== 2 * sin(45)).
      */
-    --arrow-size-diagonal: calc(var(--arrow-size) * 0.7071);
+    --arrow-offset: var(--arrow-border-size);
+    --arrow-size-diagonal: calc((var(--arrow-size) + var(--arrow-offset) * 2) * 0.7071);
     --arrow-padding-offset: calc(var(--arrow-size-diagonal) - var(--arrow-size));
 
     display: contents;
@@ -53,18 +59,22 @@ export default css`
     background: var(--arrow-color);
     z-index: 3;
     clip-path: polygon(0 100%, 100% 0, 100% 100%);
+    translate: 0 calc(var(--arrow-offset) * -1);
   }
 
   :host([data-current-placement~='left']) .arrow {
     rotate: -45deg;
+    translate: calc(var(--arrow-offset) * -1) 0;
   }
 
   :host([data-current-placement~='right']) .arrow {
     rotate: 135deg;
+    translate: var(--arrow-offset) 0;
   }
 
   :host([data-current-placement~='bottom']) .arrow {
     rotate: 225deg;
+    translate: 0 var(--arrow-offset);
   }
 
   /* Hover bridge */

--- a/packages/webawesome/src/components/popup/popup.styles.ts
+++ b/packages/webawesome/src/components/popup/popup.styles.ts
@@ -52,6 +52,7 @@ export default css`
     rotate: 45deg;
     background: var(--arrow-color);
     z-index: 3;
+    clip-path: polygon(0 100%, 100% 0, 100% 100%);
   }
 
   :host([data-current-placement~='left']) .arrow {

--- a/packages/webawesome/src/components/tooltip/tooltip.styles.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.styles.ts
@@ -53,8 +53,12 @@ export default css`
     -webkit-user-select: none;
   }
 
-  .tooltip::part(arrow) {
-    border-bottom: var(--wa-tooltip-border-width) var(--wa-tooltip-border-style) var(--wa-tooltip-border-color);
-    border-right: var(--wa-tooltip-border-width) var(--wa-tooltip-border-style) var(--wa-tooltip-border-color);
+  .tooltip {
+    --arrow-border-size: var(--wa-panel-border-width);
+
+    &::part(arrow) {
+      border-bottom: var(--wa-tooltip-border-width) var(--wa-tooltip-border-style) var(--wa-tooltip-border-color);
+      border-right: var(--wa-tooltip-border-width) var(--wa-tooltip-border-style) var(--wa-tooltip-border-color);
+    }
   }
 `;


### PR DESCRIPTION
Similar fix to #8 which was lost again during the upgrade to 3.2.1.

This includes additional CSS styling to handle tooltips/popovers/popups with borders. Technically these are not required for the home-assistant fork as it doesn't use borders on the tooltips, but hopefully it should allow the fix to be being pushed upstream (I've opened a duplicate PR is there).

I've only tested this with the webawesome sample pages, and not within the context of home-assistant - haven't yet set up my HA dev env to use the non-bundled version.