### PR TITLE
Correct tooltip arrow border size setting

### DIFF
--- a/packages/webawesome/src/components/tooltip/tooltip.styles.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.styles.ts
@@ -54,7 +54,7 @@ export default css`
   }
 
   .tooltip {
-    --arrow-border-size: var(--wa-panel-border-width);
+    --arrow-border-size: var(--wa-tooltip-border-width);
 
     &::part(arrow) {
       border-bottom: var(--wa-tooltip-border-width) var(--wa-tooltip-border-style) var(--wa-tooltip-border-color);


### PR DESCRIPTION
Should be using the tooltip border width parameter not the panel one.