### PR TITLE
server-side rendering fixups

### DIFF
--- a/packages/webawesome/src/components/drawer/drawer.ts
+++ b/packages/webawesome/src/components/drawer/drawer.ts
@@ -291,29 +291,29 @@ export default class WaDrawer extends WebAwesomeElement {
   }
 }
 
-//
-// Watch for data-drawer="open *" clicks
-//
-document.addEventListener('click', (event: MouseEvent) => {
-  const drawerAttrEl = (event.target as Element).closest('[data-drawer]');
+if (!isServer) {
+  //
+  // Watch for data-drawer="open *" clicks
+  //
+  document.addEventListener('click', (event: MouseEvent) => {
+    const drawerAttrEl = (event.target as Element).closest('[data-drawer]');
 
-  if (drawerAttrEl instanceof Element) {
-    const [command, id] = parseSpaceDelimitedTokens(drawerAttrEl.getAttribute('data-drawer') || '');
+    if (drawerAttrEl instanceof Element) {
+      const [command, id] = parseSpaceDelimitedTokens(drawerAttrEl.getAttribute('data-drawer') || '');
 
-    if (command === 'open' && id?.length) {
-      const doc = drawerAttrEl.getRootNode() as Document | ShadowRoot;
-      const drawer = doc.getElementById(id) as WaDrawer;
+      if (command === 'open' && id?.length) {
+        const doc = drawerAttrEl.getRootNode() as Document | ShadowRoot;
+        const drawer = doc.getElementById(id) as WaDrawer;
 
-      if (drawer?.localName === 'wa-drawer') {
-        drawer.open = true;
-      } else {
-        console.warn(`A drawer with an ID of "${id}" could not be found in this document.`);
+        if (drawer?.localName === 'wa-drawer') {
+          drawer.open = true;
+        } else {
+          console.warn(`A drawer with an ID of "${id}" could not be found in this document.`);
+        }
       }
     }
-  }
-});
+  });
 
-if (!isServer) {
   // Ugly, but it fixes light dismiss in Safari: https://bugs.webkit.org/show_bug.cgi?id=267688
   document.body.addEventListener('pointerdown', () => {
     /* empty */

--- a/packages/webawesome/src/internal/slot.ts
+++ b/packages/webawesome/src/internal/slot.ts
@@ -1,4 +1,4 @@
-import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { isServer, type ReactiveController, type ReactiveControllerHost } from 'lit';
 
 /** A reactive controller that determines when slots exist. */
 export class HasSlotController implements ReactiveController {
@@ -11,6 +11,11 @@ export class HasSlotController implements ReactiveController {
   }
 
   private hasDefaultSlot() {
+    // `Element#childNodes` is unavailable in Lit's SSR context
+    if (isServer) {
+      return false;
+    }
+
     return [...this.host.childNodes].some(node => {
       if (node.nodeType === Node.TEXT_NODE && node.textContent!.trim() !== '') {
         return true;
@@ -36,6 +41,11 @@ export class HasSlotController implements ReactiveController {
   }
 
   private hasNamedSlot(name: string) {
+    // `Element#querySelector` is unavailable in Lit's SSR context
+    if (isServer) {
+      return false;
+    }
+
     return this.host.querySelector(`:scope > [slot="${name}"]`) !== null;
   }
 
@@ -44,10 +54,20 @@ export class HasSlotController implements ReactiveController {
   }
 
   hostConnected() {
+    // `ShadowRoot#addEventListener` implementation in https://github.com/lit/lit/pull/4893
+    if (isServer) {
+      return;
+    }
+
     this.host.shadowRoot!.addEventListener('slotchange', this.handleSlotChange);
   }
 
   hostDisconnected() {
+    // `ShadowRoot#removeEventListener` implementation in https://github.com/lit/lit/pull/4893
+    if (isServer) {
+      return;
+    }
+
     this.host.shadowRoot!.removeEventListener('slotchange', this.handleSlotChange);
   }
 


### PR DESCRIPTION
a couple webawesome components are currently unavailable in Lit's server-side rendering context because they call unavailable methods

thankfully we [aren't the first ones](https://github.com/shoelace-style/webawesome/issues/1858) running into this issue
tldr.: page, button, and drawer all call methods that are unavailable in an SSR context (can't include a fix for page, as it is [pro only](https://webawesome.com/docs/components/page))

there is a pending [Lit PR](https://github.com/lit/lit/pull/4893) that adds more fully-featured `EventTarget` support, which removes the need to suppress `addEventListener` and `removeEventListener` calls
`childNodes` and `querySelector` remain unsupported, which are required for [`HasSlotController`](https://github.com/home-assistant/webawesome/blob/next/packages/webawesome/src/internal/slot.ts)

i don't have enough experience with webawesome to know how big of a deal it is to effectively stub out _all_ `HasSlotController` functionality

there isn't a lot of surface area to evaluate against in the device database (a [single occurrence of button](https://github.com/OHF-Device-Database/device-database/pull/82/changes/6a241403f5e1c0c281d670b675e7774468fbedc9) to be precise 🙈), but so far i did not run into any hydration mismatches
this isn't to say that they won't happen, but i think tackling those as our surface area increases is better than being blocked from using important components like `<wa-button>` outright 😅

none of these changes affect client-side rendered usage