### PR TITLE
Allow passing aria-label for buttons

### DIFF
--- a/packages/webawesome/src/components/button/button.ts
+++ b/packages/webawesome/src/components/button/button.ts
@@ -60,6 +60,9 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
 
   @property() title = ''; // make reactive to pass through
 
+  /** The accessible label for the button, propagated to the underlying `<button>` or `<a>` element. */
+  @property({ attribute: 'aria-label' }) ariaLabel: string | null = null;
+
   /** The button's theme variant. Defaults to `neutral` if not within another element with a variant. */
   @property({ reflect: true }) variant: 'neutral' | 'brand' | 'success' | 'warning' | 'danger' = 'neutral';
 
@@ -300,6 +303,7 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
         rel=${ifDefined(isLink && this.rel ? this.rel : undefined)}
         role=${ifDefined(isLink ? undefined : 'button')}
         aria-disabled=${ifDefined(isLink && this.disabled ? 'true' : undefined)}
+        aria-label=${ifDefined(this.ariaLabel ?? undefined)}
         tabindex=${this.disabled ? '-1' : '0'}
         @invalid=${this.isButton() ? this.handleInvalid : null}
         @click=${this.handleClick}


### PR DESCRIPTION
Companion PR: https://github.com/home-assistant/frontend/pull/51784

Won't open for upstream due to previous rejection for aria attributes (https://github.com/home-assistant/webawesome/pull/22)