### PR TITLE
Keep the button label accessible while loading

### DIFF
--- a/packages/webawesome/src/components/button/button.styles.ts
+++ b/packages/webawesome/src/components/button/button.styles.ts
@@ -317,6 +317,9 @@ export default css`
     .caret {
       /* Hidden with opacity, not visibility, so the label stays in the accessibility tree */
       opacity: 0;
+
+      /* Unlike visibility: hidden, opacity leaves the content clickable */
+      pointer-events: none;
     }
 
     wa-spinner {

--- a/packages/webawesome/src/components/button/button.styles.ts
+++ b/packages/webawesome/src/components/button/button.styles.ts
@@ -315,7 +315,8 @@ export default css`
     .label,
     .end,
     .caret {
-      visibility: hidden;
+      /* Hidden with opacity, not visibility, so the label stays in the accessibility tree */
+      opacity: 0;
     }
 
     wa-spinner {

--- a/packages/webawesome/src/components/button/button.test.ts
+++ b/packages/webawesome/src/components/button/button.test.ts
@@ -46,6 +46,23 @@ describe('<wa-button>', () => {
           const el = await fixture<WaButton>(html` <wa-button disabled>Button Label</wa-button> `);
           await expect(el).to.be.accessible();
         });
+
+        it('should be accessible when loading', async () => {
+          const el = await fixture<WaButton>(html` <wa-button loading><span>Button Label</span></wa-button> `);
+          await expect(el).to.be.accessible();
+        });
+
+        it('should keep the label in the accessibility tree when loading', async () => {
+          const el = await fixture<WaButton>(html` <wa-button loading><span>Button Label</span></wa-button> `);
+          const label = el.querySelector('span')!;
+          expect(getComputedStyle(label).visibility).to.not.equal('hidden');
+        });
+
+        it('should set aria-busy when loading', async () => {
+          const el = await fixture<WaButton>(html` <wa-button loading>Button Label</wa-button> `);
+          const button = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="base"]')!;
+          expect(button.getAttribute('aria-busy')).to.equal('true');
+        });
       });
 
       describe('properties', () => {

--- a/packages/webawesome/src/components/button/button.test.ts
+++ b/packages/webawesome/src/components/button/button.test.ts
@@ -3,6 +3,7 @@ import { html } from 'lit';
 import sinon from 'sinon';
 import { fixtures } from '../../internal/test/fixture.js';
 import { runFormControlBaseTests } from '../../internal/test/form-control-base-tests.js';
+import { clickOnElement } from '../../internal/test/pointer-utilities.js';
 import type WaButton from './button.js';
 
 const variants = ['brand', 'success', 'neutral', 'warning', 'danger'];
@@ -56,6 +57,18 @@ describe('<wa-button>', () => {
           const el = await fixture<WaButton>(html` <wa-button loading><span>Button Label</span></wa-button> `);
           const label = el.querySelector('span')!;
           expect(getComputedStyle(label).visibility).to.not.equal('hidden');
+        });
+
+        it('should not let clicks reach the hidden label when loading', async () => {
+          const el = await fixture<WaButton>(html` <wa-button loading><span>Button Label</span></wa-button> `);
+          const label = el.querySelector('span')!;
+          const labelHandler = sinon.spy();
+          label.addEventListener('click', labelHandler);
+
+          // Away from the centre, where the spinner sits
+          await clickOnElement(label, 'left');
+
+          expect(labelHandler).not.to.have.been.called;
         });
 
         it('should set aria-busy when loading', async () => {

--- a/packages/webawesome/src/components/button/button.ts
+++ b/packages/webawesome/src/components/button/button.ts
@@ -340,6 +340,7 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
         role=${ifDefined(isLink ? undefined : 'button')}
         aria-disabled=${ifDefined(isLink && this.disabled ? 'true' : undefined)}
         aria-label=${ifDefined(this.ariaLabel ?? undefined)}
+        aria-busy=${this.loading ? 'true' : 'false'}
         tabindex=${this.disabled ? '-1' : '0'}
         @invalid=${this.isButton() ? this.handleInvalid : null}
         @click=${this.handleClick}


### PR DESCRIPTION
Carries the upstream fix for `<wa-button>` losing its accessible name while `loading`, so the frontend can pick it up without waiting for a Web Awesome release.

- Upstream issue: https://github.com/shoelace-style/webawesome/issues/2693
- Upstream PR: https://github.com/shoelace-style/webawesome/pull/2694

Same change as the upstream PR, minus the changelog entry, which would conflict on the next upstream merge.

## The problem

While `loading` is set, the button hid its content with `visibility: hidden`. That removes the content from the accessibility tree, so the label stopped contributing to the button's accessible name, and nothing reported the busy state.

`visibility` is inherited, and slotted content inherits from the slot it is assigned to. The rule therefore reached across the shadow boundary into markup the consumer wrote. That matters for us in particular: our wrappers pass the label through their own slot, so the label reaches `<wa-button>` through a second slot and the name was lost in every case, not just some.

Measured against this branch's build with Chrome's native accessibility tree (CDP `Accessibility.getFullAXTree`):

| markup | before | after |
| --- | --- | --- |
| `<wa-button loading><span>Save changes</span></wa-button>` | `"Loading"`, no busy state | `"Save changes Loading"`, `busy: true` |
| same without `loading` | `"Save changes"` | `"Save changes"` |

The `"Loading"` came from the spinner's own `role="progressbar"` label, not from the button. In the frontend the effect was the same, checked on `ha-progress-button` in both its `progress` and its post-action result state.

## What changed

- `button.styles.ts`: hide the content with `opacity: 0` instead of `visibility: hidden`.
- `button.ts`: set `aria-busy` on the rendered element while loading, next to the existing `aria-label` binding.
- `button.test.ts`: three cases in the existing `accessibility` block.

No visual change. I measured the host and internal `.button` box across 12 label shapes: 0.000 px difference in both dimensions, so a loading button still reserves its full width.

## Verification

`CSR_ONLY=true npx web-test-runner --group button` passes in Chromium and Firefox.

The SSR fixture fails in my local checkout with `Unknown command lit-ssr-render`, but it fails the same way on a clean `next` without this change (182 failures before, 188 after, which is the same failures plus my 6 new test instances). So that is a pre-existing tooling gap here, not a regression.

With the CSS change reverted, `should keep the label in the accessibility tree when loading` fails, so the test is a real guard.

## Next steps

I have left the version bump out, so you can decide whether this goes into a `3.7.0-ha.1` on its own or waits for the next upstream upgrade. Once it is published, the frontend needs a dependency bump to pick it up. Until then, `ha-progress-button` stays unnamed while an action is in flight, so it is worth releasing rather than holding for the next upgrade.
