### PR TITLE
Add configurable inputId to wa-input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14770,7 +14770,7 @@
     },
     "packages/webawesome": {
       "name": "@home-assistant/webawesome",
-      "version": "3.7.0",
+      "version": "3.7.0-ha.1",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "4.1.0",

--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "description": "A forward-thinking library of web components.",
-  "version": "3.7.0-ha.0",
+  "version": "3.7.0-ha.1",
   "homepage": "https://webawesome.com/",
   "author": "Web Awesome",
   "license": "MIT",

--- a/packages/webawesome/src/components/input/input.test.ts
+++ b/packages/webawesome/src/components/input/input.test.ts
@@ -79,6 +79,24 @@ describe('<wa-input>', () => {
           const input = el.shadowRoot!.querySelector<HTMLInputElement>('input')!;
           expect(input.placeholder).to.equal('Enter text');
         });
+
+        it('should use "input" as the default native input id and label for', async () => {
+          const el = await fixture<WaInput>(html`<wa-input label="Name"></wa-input>`);
+          const input = el.shadowRoot!.querySelector<HTMLInputElement>('input')!;
+          const label = el.shadowRoot!.querySelector<HTMLLabelElement>('[part~="form-control-label"]')!;
+          expect(el.inputId).to.equal('input');
+          expect(input.id).to.equal('input');
+          expect(label.htmlFor).to.equal('input');
+        });
+
+        it('should set the native input id and label for from input-id', async () => {
+          const el = await fixture<WaInput>(html`<wa-input input-id="username" label="Username"></wa-input>`);
+          const input = el.shadowRoot!.querySelector<HTMLInputElement>('input')!;
+          const label = el.shadowRoot!.querySelector<HTMLLabelElement>('[part~="form-control-label"]')!;
+          expect(el.inputId).to.equal('username');
+          expect(input.id).to.equal('username');
+          expect(label.htmlFor).to.equal('username');
+        });
       });
 
       describe('slots', () => {

--- a/packages/webawesome/src/components/input/input.ts
+++ b/packages/webawesome/src/components/input/input.ts
@@ -228,6 +228,12 @@ export default class WaInput extends WebAwesomeFormAssociatedElement {
    */
   @property({ attribute: 'with-hint', type: Boolean }) withHint = false;
 
+  /**
+   * Sets the native input's `id` and the associated label `for`. Defaults to `"input"`. Use a unique value when
+   * multiple inputs are present so consumers such as password managers can tell them apart.
+   */
+  @property({ attribute: 'input-id' }) inputId = 'input';
+
   private handleChange(event: Event) {
     this.value = this.input.value;
 
@@ -385,7 +391,7 @@ export default class WaInput extends WebAwesomeFormAssociatedElement {
           label: true,
           'has-label': hasLabel,
         })}
-        for="input"
+        for=${this.inputId || 'input'}
         aria-hidden=${hasLabel ? 'false' : 'true'}
       >
         <slot name="label">${this.label}</slot>
@@ -396,7 +402,7 @@ export default class WaInput extends WebAwesomeFormAssociatedElement {
 
         <input
           part="input"
-          id="input"
+          id=${this.inputId || 'input'}
           class="control"
           type=${this.type === 'password' && this.passwordVisible ? 'text' : this.type}
           title=${this.title /* An empty title prevents browser validation tooltips from appearing on hover */}


### PR DESCRIPTION
## Summary

Adds an `inputId` / `input-id` property to `wa-input` so consumers can set the native `<input>` `id` and matching label `for`. Defaults to `"input"` to preserve existing behavior.

This unblocks unique native ids for login fields in Home Assistant (username, password, etc.) and helps password managers distinguish fields on forms with multiple inputs.

Related:
- home-assistant/frontend#51620
- home-assistant/frontend#54076

## Test plan

- [x] Unit tests verify default `id="input"` and label `for="input"`
- [x] Unit tests verify `input-id="username"` sets native `input.id` and label `htmlFor` to `username`
- [x] Existing `wa-input` test suite passes